### PR TITLE
fixed the word-wrap of feature-info

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,10 @@
             background-color: white !important;
             box-shadow: 0 0 0 1000px white inset !important;
         }
+        .leaflet-popup-content {
+            white-space: normal;
+            word-wrap: break-word;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
Fixes the word wrapping in the feature info. 

before: 
![image (1)](https://github.com/user-attachments/assets/56467073-6e56-4b9c-b9d2-3cc76ffe34f2)

After: 
![Screenshot 2025-02-17 at 10 31 23 AM](https://github.com/user-attachments/assets/6a355855-74c8-4f9f-892a-020c6f2c276d)
